### PR TITLE
feat: add statscan_data example for R and Python

### DIFF
--- a/statscan_data/ExtractionViaPython.ipynb
+++ b/statscan_data/ExtractionViaPython.ipynb
@@ -11,7 +11,64 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Collecting package metadata (current_repodata.json): done\n",
+      "Solving environment: done\n",
+      "\n",
+      "\n",
+      "==> WARNING: A newer version of conda exists. <==\n",
+      "  current version: 4.8.2\n",
+      "  latest version: 4.8.3\n",
+      "\n",
+      "Please update conda by running\n",
+      "\n",
+      "    $ conda update -n base conda\n",
+      "\n",
+      "\n",
+      "\n",
+      "## Package Plan ##\n",
+      "\n",
+      "  environment location: /opt/conda\n",
+      "\n",
+      "  added / updated specs:\n",
+      "    - stats_can\n",
+      "\n",
+      "\n",
+      "The following packages will be downloaded:\n",
+      "\n",
+      "    package                    |            build\n",
+      "    ---------------------------|-----------------\n",
+      "    stats_can-2.2.3            |             py_1          64 KB  ian.e.preston\n",
+      "    ------------------------------------------------------------\n",
+      "                                           Total:          64 KB\n",
+      "\n",
+      "The following NEW packages will be INSTALLED:\n",
+      "\n",
+      "  stats_can          ian.e.preston/noarch::stats_can-2.2.3-py_1\n",
+      "\n",
+      "\n",
+      "\n",
+      "Downloading and Extracting Packages\n",
+      "stats_can-2.2.3      | 64 KB     | ##################################### | 100% \n",
+      "Preparing transaction: done\n",
+      "Verifying transaction: done\n",
+      "Executing transaction: done\n"
+     ]
+    }
+   ],
+   "source": [
+    "!conda install -y --use-local -c ian.e.preston stats_can"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -21,10 +78,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
+    "import os\n",
+    "os.makedirs(\"data\", exist_ok=True)\n",
     "sc = StatsCan(data_folder=\"data\")"
    ]
   },
@@ -44,24 +103,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 3,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Downloading and loading table_27100022\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "df = sc.table_to_df(\"271-000-22-01\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
@@ -74,7 +125,7 @@
        "      dtype='object')"
       ]
      },
-     "execution_count": 14,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -85,7 +136,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -263,7 +314,7 @@
        "4          t        0  "
       ]
      },
-     "execution_count": 13,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -281,7 +332,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -459,7 +510,7 @@
        "884         0  "
       ]
      },
-     "execution_count": 16,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -477,7 +528,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -607,7 +658,7 @@
        "1166    NaN          t        0  "
       ]
      },
-     "execution_count": 17,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -625,7 +676,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -641,7 +692,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
@@ -660,7 +711,7 @@
        "  'memberUomCode': 223}]"
       ]
      },
-     "execution_count": 19,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -678,30 +729,30 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
        "[{'responseStatusCode': 0,\n",
-       "  'productId': 22100005,\n",
-       "  'releaseTime': '2020-05-05T08:30'},\n",
+       "  'productId': 13100766,\n",
+       "  'releaseTime': '2020-05-12T08:30'},\n",
        " {'responseStatusCode': 0,\n",
-       "  'productId': 22100006,\n",
-       "  'releaseTime': '2020-05-05T08:30'},\n",
+       "  'productId': 10100131,\n",
+       "  'releaseTime': '2020-05-12T08:30'},\n",
        " {'responseStatusCode': 0,\n",
-       "  'productId': 12100119,\n",
-       "  'releaseTime': '2020-05-05T08:30'},\n",
-       " {'responseStatusCode': 0,\n",
-       "  'productId': 12100011,\n",
-       "  'releaseTime': '2020-05-05T08:30'},\n",
+       "  'productId': 10100136,\n",
+       "  'releaseTime': '2020-05-12T08:30'},\n",
        " {'responseStatusCode': 0,\n",
        "  'productId': 33100036,\n",
-       "  'releaseTime': '2020-05-05T08:30'}]"
+       "  'releaseTime': '2020-05-12T08:30'},\n",
+       " {'responseStatusCode': 0,\n",
+       "  'productId': 10100139,\n",
+       "  'releaseTime': '2020-05-12T08:30'}]"
       ]
      },
-     "execution_count": 20,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -719,7 +770,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
@@ -742,7 +793,7 @@
        "  'releaseTime': '2020-04-29T08:30'}]"
       ]
      },
-     "execution_count": 21,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -753,7 +804,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
@@ -809,7 +860,7 @@
        "2013-01-01   232910.0"
       ]
      },
-     "execution_count": 22,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -827,7 +878,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -836,7 +887,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
@@ -845,7 +896,7 @@
        "dict_keys(['scalar', 'frequency', 'symbol', 'status', 'uom', 'survey', 'subject', 'classificationType', 'securityLevel', 'terminated', 'wdsResponseStatus'])"
       ]
      },
-     "execution_count": 35,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -856,7 +907,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
     {
@@ -964,7 +1015,7 @@
        "9                 9               billions              milliards"
       ]
      },
-     "execution_count": 36,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -972,6 +1023,13 @@
    "source": [
     "codes['scalar']"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/statscan_data/ExtractionViaR.ipynb
+++ b/statscan_data/ExtractionViaR.ipynb
@@ -11,7 +11,28 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Updating HTML index of packages in '.Library'\n",
+      "\n",
+      "Making 'packages.html' ...\n",
+      " done\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "install.packages(\"cansim\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -34,7 +55,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -52,7 +73,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -159,7 +180,7 @@
     }
    ],
    "source": [
-    "tail(births)"
+    "tail(table)"
    ]
   },
   {
@@ -171,9 +192,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Warning message:\n",
+      "“`as.tibble()` is deprecated as of tibble 2.0.0.\n",
+      "Please use `as_tibble()` instead.\n",
+      "The signature and semantics have changed, see `?as_tibble`.\n",
+      "\u001b[90mThis warning is displayed once every 8 hours.\u001b[39m\n",
+      "\u001b[90mCall `lifecycle::last_warnings()` to see where this warning was generated.\u001b[39m”\n"
+     ]
+    },
     {
      "data": {
       "text/html": [
@@ -251,7 +284,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
@@ -316,14 +349,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Your CANSIM table overview data is 68 days old.\n",
+      "Your CANSIM table overview data is 75 days old.\n",
       "Consider setting options(cansim.cache_path=\"your cache path\")\n",
       "in your .Rprofile and refreshing the table via list_cansim_tables(refresh=TRUE).\n",
       "\n",
@@ -509,7 +542,7 @@
    "mimetype": "text/x-r-source",
    "name": "R",
    "pygments_lexer": "r",
-   "version": "3.6.2"
+   "version": "3.6.3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Based on Christian's PR, but with small fixes. Users do a local install of `cansim` and a python library to pull statscan datasets into their notebooks.