### PR TITLE
feat(kfp): Add two kfp examples with reusable/lightweight components

### DIFF
--- a/mapreduce-pipeline/Compute-Pi-with-lightweight-components-and-minio.ipynb
+++ b/mapreduce-pipeline/Compute-Pi-with-lightweight-components-and-minio.ipynb
@@ -1,0 +1,783 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Difficulty: Intermediate**\n",
+    "\n",
+    "# Summary:\n",
+    "\n",
+    "This example demonstrates:\n",
+    "* building a pipeline with lightweight components (components defined here in python code)\n",
+    "* Saving results to minio\n",
+    "* Running parallel processes, where parallelism is defined at runtime\n",
+    "\n",
+    "In doing this, we build a **shareable** pipeline - one that you can share with others and they can rerun on a new problem without needing this notebook.\n",
+    "\n",
+    "This example builds on concepts from a few others - see those notebooks for more detail: \n",
+    "* The problem solved here is from [Compute Pi](../mapreduce-pipeline/Compute-Pi.ipynb) \n",
+    "* We use lightweight components, which have some important [quirks](../kfp-basics/demo_kfp_lightweight_components.ipynb)\n",
+    "\n",
+    "**Note:** Although we demonistrate how to make lightweight components that interact directly with minio, this reduces code reusability and makes things harder to test.  A more reusable/testable version of this is given in [Compute Pi with Reusable Components](Compute-Pi-with-reusable-components-and-minio.ipynb)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from typing import List\n",
+    "\n",
+    "import kfp\n",
+    "from kfp import dsl, compiler\n",
+    "from kfp.components import func_to_container_op\n",
+    "\n",
+    "# TODO: Move utilities to a central repo\n",
+    "from utilities import get_minio_credentials, copy_to_minio\n",
+    "from utilities import minio_find_files_matching_pattern"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Problem Description\n",
+    "\n",
+    "Our task is to compute an estimate of Pi by:\n",
+    "1. picking some random points\n",
+    "1. evaluating whether the points are inside a unit circle\n",
+    "1. aggregating (2) to estimate pi\n",
+    "\n",
+    "Our solution to this task here focuses on:\n",
+    "* making a fully reusable pipeline:\n",
+    "    * The pipeline should be sharable.  You should be able to share the pipeline by giving them the pipeline.yaml file **without** sharing this notebook\n",
+    "    * All user inputs are adjustable at runtime (no editing the YAML, changing hard-coded settings in the python code, etc.)\n",
+    "* persisting data in minio\n",
+    "* using existing, reusable components where possible\n",
+    "    * Ex: rather than teach our sample function to store results in minio, we use an existing component to store results\n",
+    "    * This helps improve testability and reduces work when building new pipelines"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Pipeline pseudocode"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To solve our problem, we need to: \n",
+    "* Generate N random seeds\n",
+    "    * For each random seed, do a sample step\n",
+    "    * For each sample step, store the result to a location in minio\n",
+    "* Collect all sample results\n",
+    "* Compute pi (by averaging the results)\n",
+    "* Save the final result to minio"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In pseudocode our pipeline looks like:"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "```python\n",
+    "def compute_pi(n_samples: int,\n",
+    "               output_location: str,\n",
+    "               minio_credentials, \n",
+    "              ):\n",
+    "    seeds = create_seeds(n_samples)\n",
+    "\n",
+    "    for seed in seeds:\n",
+    "        result = sample(seed, minio_credentials, output_location)\n",
+    "    \n",
+    "    all_sample_results = collect_all_results(minio_credentials,\n",
+    "                                             sample_output_location\n",
+    "                                            )\n",
+    "    \n",
+    "    final_result = average(all_sample_results)\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "where we've pulled anything the user might want to set at runtime (the number of samples, the location in minio for results to be placed, and their minio credentials) out as pipeline arguments.\n",
+    "\n",
+    "Now lets fill in all the function calls with components"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Define Pipeline Operations as Functions"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## create_seeds"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def create_seeds_func(n_samples: int) -> list:\n",
+    "    \"\"\"\n",
+    "    Creates n_samples seeds and returns as a list\n",
+    "\n",
+    "    Note: When used as an operation in a KF pipeline, the list is serialized\n",
+    "    to a string.  Can deserialize with strip and split or json package\n",
+    "    This sort of comma separated list will work natively with KF Pipelines'\n",
+    "    parallel for (we can feed this directly into a parallel for loop and it\n",
+    "    breaks into elements for us)\n",
+    "\n",
+    "    \"\"\"\n",
+    "    constant = 10  # just so I know something is happening\n",
+    "    return [constant + i for i in range(n_samples)]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "By defining this function in python first, we can test it here to make sure it works as expected (rigorous testing omitted here, but recommended for your own tasks)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[10, 11, 12, 13, 14, 15, 16, 17, 18, 19]\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Very rigorous testing!\n",
+    "print(create_seeds_func(10))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "And we can then convert our tested function to a task constructor using `func_to_container_op`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Define the base image our code will run from.\n",
+    "# This is reused in a few components\n",
+    "base_image_python = \"python:3.7.6-buster\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "create_seeds_op = func_to_container_op(create_seeds_func,\n",
+    "                                       base_image=base_image_python,\n",
+    "                                       )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This task constructor `create_seeds_op` is what actually creates instances of these components in our pipeline.  "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## sample"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Similar to above, we a sample function and corresponding task constructor.  For this, we need several helper functions for minio (kept in `utilities.py`).  These helpers are automatically passed to our pipeline by `func_to_container_op` "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def sample_func(seed: int, minio_url: str, minio_bucket: str,\n",
+    "                minio_access_key: str, minio_secret_key: str,\n",
+    "                minio_output_path: str) -> str:\n",
+    "    \"\"\"\n",
+    "    Define the \"sample\" pipeline operation\n",
+    "\n",
+    "    Args:\n",
+    "        seed (int): Seed for the sample operation\n",
+    "        minio_settings (str): JSON string with:\n",
+    "        minio_url: minio endpoint for storage, without \"http://, eg:\n",
+    "                   minimal-tenant1-minio.minio:9000\n",
+    "        minio_bucket: minio bucket to use within the endpoint, eg:\n",
+    "                      firstname-lastname\n",
+    "        minio_access_key: minio access key (from\n",
+    "                          /vault/secrets/minio-minimal-tenant1 on notebook\n",
+    "                          server)\n",
+    "        minio_secret_key: minio secret key (from \n",
+    "                          /vault/secrets/minio-minimal-tenant1 on notebook\n",
+    "                          server)\n",
+    "        minio_output_path (str): Path in minio to put output data.  Will place\n",
+    "                                 x.out, y.out, result.out, and seed.out in\n",
+    "                                 ./seed_{seed}/\n",
+    "\n",
+    "    Returns:\n",
+    "        (str): Minio path where data is saved (common convention in kfp to\n",
+    "               return this, even if it was specified as an input like\n",
+    "               minio_output_path)\n",
+    "    \"\"\"\n",
+    "    import json\n",
+    "    from minio import Minio\n",
+    "    import random\n",
+    "    random.seed(seed)\n",
+    "\n",
+    "    print(\"Pick random point\")\n",
+    "    # x,y ~ Uniform([-1,1])\n",
+    "    x = random.random() * 2 - 1\n",
+    "    y = random.random() * 2 - 1\n",
+    "    print(f\"Sample selected: ({x}, {y})\")\n",
+    "\n",
+    "    if (x ** 2 + y ** 2) <= 1:\n",
+    "        print(f\"Random point is inside the unit circle\")\n",
+    "        result = 4\n",
+    "    else:\n",
+    "        print(f\"Random point is outside the unit circle\")\n",
+    "        result = 0\n",
+    "\n",
+    "    to_output = {\n",
+    "        'x': x,\n",
+    "        'y': y,\n",
+    "        'result': result,\n",
+    "        'seed': seed,\n",
+    "    }\n",
+    "\n",
+    "    # Store all results to bucket\n",
+    "    # Store each of x, y, result, and seed to a separate file with name\n",
+    "    #   {bucket}/output_path/seed_{seed}/x.out\n",
+    "    #   {bucket}/output_path/seed_{seed}/y.out\n",
+    "    #   ...\n",
+    "    # where each file has just the value of the output.\n",
+    "    #\n",
+    "    # Could also have stored them all together in a single json file\n",
+    "    for varname, value in to_output.items():\n",
+    "        # TODO: Make this really a temp file...\n",
+    "        tempfile = f\"{varname}.out\"\n",
+    "        with open(tempfile, 'w') as fout:\n",
+    "            fout.write(str(value))\n",
+    "\n",
+    "        destination = f\"{minio_output_path.rstrip('/')}/seed_{seed}/{tempfile}\"\n",
+    "\n",
+    "        # Put file in minio\n",
+    "        copy_to_minio(minio_url=minio_url,\n",
+    "                      bucket=minio_bucket,\n",
+    "                      access_key=minio_access_key,\n",
+    "                      secret_key=minio_secret_key,\n",
+    "                      sourcefile=tempfile,\n",
+    "                      destination=destination\n",
+    "                      )\n",
+    "\n",
+    "    # Return path containing outputs (common pipeline convention)\n",
+    "    return minio_output_path"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# (insert your testing here)\n",
+    "\n",
+    "# # Example:\n",
+    "# # NOTE: These tests actually write to minio!\n",
+    "# minio_settings = get_minio_credentials(\"minimal\")\n",
+    "# minio_settings['bucket'] = 'andrew-scribner'\n",
+    "# sample = sample_func(5,\n",
+    "#                      minio_url=minio_settings['url'],\n",
+    "#                      minio_bucket=minio_settings['bucket'],\n",
+    "#                      minio_access_key=minio_settings['access_key'],\n",
+    "#                      minio_secret_key=minio_settings['secret_key'],\n",
+    "#                      minio_output_path='test_functions'\n",
+    "#                      )\n",
+    "# # Check the bucket/output_path to see if things wrote correctly"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We set `modules_to_capture=['utilities']` and `use_code_pickling=True` because this will pass our helpers to our pipeline.  "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sample_op = func_to_container_op(sample_func,\n",
+    "                                 base_image=base_image_python,\n",
+    "                                 use_code_pickling=True,  # Required because of helper functions\n",
+    "                                 modules_to_capture=['utilities'],  # Required because of helper functions\n",
+    "                                 packages_to_install=['minio'],\n",
+    "                                 )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## collect_results"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To collect results from our sample operations, we glob from minio and output result data as a JSON list\n",
+    "\n",
+    "Again, we need a helper file that feels better housed in a shared repo"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def collect_results_as_list(search_location: str, search_pattern: str,\n",
+    "                            minio_url: str, minio_bucket: str,\n",
+    "                            minio_access_key: str, minio_secret_key: str,\n",
+    "                            ) -> List[float]:\n",
+    "    \"\"\"\n",
+    "    Concatenates all files in minio that match a pattern\n",
+    "    \"\"\"\n",
+    "    from minio import Minio\n",
+    "    import json\n",
+    "\n",
+    "    obj_names = minio_find_files_matching_pattern(\n",
+    "        minio_url=minio_url,\n",
+    "        bucket=minio_bucket,\n",
+    "        access_key=minio_access_key,\n",
+    "        secret_key=minio_secret_key,\n",
+    "        pattern=search_pattern,\n",
+    "        prefix=search_location)\n",
+    "\n",
+    "    s3 = Minio(endpoint=minio_url,\n",
+    "               access_key=minio_access_key,\n",
+    "               secret_key=minio_secret_key,\n",
+    "               secure=False,\n",
+    "               region=\"us-west-1\",\n",
+    "               )\n",
+    "\n",
+    "    # TODO: Use actual temp files\n",
+    "    to_return = [None] * len(obj_names)\n",
+    "    for i, obj_name in enumerate(obj_names):\n",
+    "        tempfile = f\"./unique_temp_{i}\"\n",
+    "        s3.fget_object(minio_bucket,\n",
+    "                       object_name=obj_name,\n",
+    "                       file_path=tempfile\n",
+    "                       )\n",
+    "        with open(tempfile, 'r') as fin:\n",
+    "            to_return[i] = float(fin.read())\n",
+    "\n",
+    "    print(f\"Returning {to_return}\")\n",
+    "    return to_return"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# (insert your testing here)\n",
+    "\n",
+    "# # Example:\n",
+    "# # This only works if you make a directory with some \"./something/result.out\"\n",
+    "# # files in it\n",
+    "# pattern = re.compile(r\".*/result.out$\")\n",
+    "# collect_results_as_list(search_location='map-reduce-output/seeds/',\n",
+    "#                         search_pattern=pattern,\n",
+    "#                         minio_url=minio_settings['url'],\n",
+    "#                         minio_bucket=minio_settings['bucket'],\n",
+    "#                         minio_access_key=minio_settings['access_key'],\n",
+    "#                         minio_secret_key=minio_settings['secret_key'],\n",
+    "#                         )\n",
+    "# # (you should see all the result.out files in the bucket/location you're pointed to)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "collect_results_op = func_to_container_op(collect_results_as_list,\n",
+    "                                          base_image=base_image_python,\n",
+    "                                          use_code_pickling=True,  # Required because of helper functions\n",
+    "                                          modules_to_capture=['utilities'],  # Required because of helper functions\n",
+    "                                          packages_to_install=[\"minio\"],\n",
+    "                                          )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## average"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Average takes a JSON list of numbers and returns their mean as a float"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def average_func(numbers) -> float:\n",
+    "    \"\"\"\n",
+    "    Computes the average value of a JSON list of numbers, returned as a float\n",
+    "    \"\"\"\n",
+    "    import json\n",
+    "    print(numbers)\n",
+    "    print(type(numbers))\n",
+    "    numbers = json.loads(numbers)\n",
+    "    return sum(numbers) / len(numbers)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "average_op = func_to_container_op(average_func,\n",
+    "                                  base_image=base_image_python,\n",
+    "                                  )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Define and Compile Pipeline"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "With our component constructors defined, we build our full pipeline.  Remember that while we use a python function to define our pipeline here, anything that depends on a KFP-specific entity (an input argument, a component result, etc) is computed at runtime in kubernetes.  This means we can't do things like \n",
+    "```\n",
+    "for seed in seeds:\n",
+    "    sample_op = sample_op(seed)\n",
+    "```\n",
+    "because Python would try to interpret seeds, which is a *placeholder* object for a future value, as an iterable."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "@dsl.pipeline(\n",
+    "    name=\"Estimate Pi w/Minio\",\n",
+    "    description=\"Extension of the Map-Reduce example using dynamic number of samples and Minio for storage\"\n",
+    ")\n",
+    "def compute_pi(n_samples: int, output_location: str, minio_bucket: str, minio_url,\n",
+    "               minio_access_key: str, minio_secret_key: str):\n",
+    "    seeds = create_seeds_op(n_samples)\n",
+    "\n",
+    "    # We add the KFP RUN_ID here in the output location so that we don't\n",
+    "    # accidentally overwrite another run.  There's lots of ways to manage\n",
+    "    # data, this is just one possibility.\n",
+    "    # Ensure you avoid double \"/\"s in the path - minio does not like this\n",
+    "    this_run_output_location = f\"{str(output_location).rstrip('/')}\" \\\n",
+    "                               f\"/{kfp.dsl.RUN_ID_PLACEHOLDER}\"\n",
+    "\n",
+    "    sample_output_location = f\"{this_run_output_location}/seeds\"\n",
+    "\n",
+    "    sample_ops = []\n",
+    "    with kfp.dsl.ParallelFor(seeds.output) as seed:\n",
+    "        sample_op_ = sample_op(seed, minio_url, minio_bucket, minio_access_key,\n",
+    "                               minio_secret_key, sample_output_location)\n",
+    "        # Make a list of sample_ops so we can do result collection after they finish\n",
+    "        sample_ops.append(sample_op_)\n",
+    "\n",
+    "        # NOTE: A current limitation of the ParallelFor loop in KFP is that it\n",
+    "        # does not give us an easy way to collect the results afterwards.  To\n",
+    "        # get around this problem, we store results in a known place in minio\n",
+    "        # and later glob the result files back out\n",
+    "\n",
+    "    # Find result files that exist in the seed output location\n",
+    "    # Note that a file in the bucket root does not have a preceeding slash, so\n",
+    "    # to handle the (unlikely) event we've put all results in the bucket root,\n",
+    "    # check for either ^result.out (eg, entire string is just the result.out)\n",
+    "    # or /result.out.  This is to avoid matching something like\n",
+    "    # '/path/i_am_not_a_result.out'\n",
+    "    search_pattern = r'.*(^|/)result.out'\n",
+    "\n",
+    "    # Collect all result.txt files in the sample_output_location and read them\n",
+    "    # into a list\n",
+    "    collect_results_op_ = collect_results_op(\n",
+    "        search_location=sample_output_location,\n",
+    "        search_pattern=search_pattern,\n",
+    "        minio_url=minio_url,\n",
+    "        minio_bucket=minio_bucket,\n",
+    "        minio_access_key=minio_access_key,\n",
+    "        minio_secret_key=minio_secret_key,\n",
+    "    )\n",
+    "\n",
+    "    # collect_results requires all sample_ops to be done before running (all\n",
+    "    # results must be generated first).  Enforce this by setting files_to_cat\n",
+    "    # to be .after() all copy_op tasks\n",
+    "    for s in sample_ops:\n",
+    "        collect_results_op_.after(s)\n",
+    "\n",
+    "    average_op(collect_results_op_.output)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Compile our pipeline into a reusable YAML file"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exported pipeline definition to compute-pi-with-lightweight.zip\n"
+     ]
+    }
+   ],
+   "source": [
+    "experiment_name = \"compute-pi-with-lightweight\"\n",
+    "experiment_yaml_zip = experiment_name + '.zip'\n",
+    "compiler.Compiler().compile(\n",
+    "    compute_pi,\n",
+    "    experiment_yaml_zip\n",
+    ")\n",
+    "print(f\"Exported pipeline definition to {experiment_yaml_zip}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Run"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Use our above pipeline definition to do our task.  Note that anything below here can be done **without** the above code.  All we need is the yaml file from the last step.  We can even do this from the Kubeflow Pipelines UI or from a terminal."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## User settings\n",
+    "Update the next block to match your own setup.  bucket will be your namespace (likely your firstname-lastname), and output_location is where inside the bucket you want to put your results"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Python Minio SDK expects bucket and output_location to be separate\n",
+    "bucket = \"andrew-scribner\"\n",
+    "output_location = \"map-reduce-output-lw\"\n",
+    "n_samples = 10\n",
+    "minio_tenant = \"minimal\"  # probably can leave this as is"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Other settings\n",
+    "(leave this as is)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Trying to access minio credentials from:\n",
+      "/vault/secrets/minio-minimal-tenant1\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Get minio credentials using a helper\n",
+    "minio_settings = get_minio_credentials(minio_tenant)\n",
+    "minio_url = minio_settings[\"url\"]\n",
+    "minio_access_key = minio_settings[\"access_key\"]\n",
+    "minio_secret_key = minio_settings[\"secret_key\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "Experiment link <a href=\"/pipeline/#/experiments/details/745736c2-db59-4b06-bbea-94d83d30d256\" target=\"_blank\" >here</a>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "Run link <a href=\"/pipeline/#/runs/details/bf7c90c1-4b21-4cc0-8fce-ac8816c4260c\" target=\"_blank\" >here</a>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "client = kfp.Client()\n",
+    "result = client.create_run_from_pipeline_func(\n",
+    "    compute_pi,\n",
+    "    arguments={\"n_samples\": n_samples,\n",
+    "               \"output_location\": output_location,\n",
+    "               \"minio_bucket\": bucket,\n",
+    "               \"minio_url\": minio_url,\n",
+    "               \"minio_access_key\": minio_access_key,\n",
+    "               \"minio_secret_key\": minio_secret_key,\n",
+    "               },\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "(Optional)\n",
+    "\n",
+    "Wait for the run to complete, then print that it is done"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "wait_result = result.wait_for_run_completion(timeout=300)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Run bf7c90c1-4b21-4cc0-8fce-ac8816c4260c\n",
+      "\tstarted at \t2020-06-26 17:54:20+00:00\n",
+      "\tfinished at \t2020-06-26 17:55:58+00:00\n",
+      "\twith status Succeeded\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(f\"Run {wait_result.run.id}\\n\\tstarted at \\t{wait_result.run.created_at}\\n\\tfinished at \\t{wait_result.run.finished_at}\\n\\twith status {wait_result.run.status}\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/mapreduce-pipeline/Compute-Pi-with-reusable-components-and-minio.ipynb
+++ b/mapreduce-pipeline/Compute-Pi-with-reusable-components-and-minio.ipynb
@@ -1,0 +1,696 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Difficulty: Intermediate**\n",
+    "\n",
+    "# Summary:\n",
+    "\n",
+    "This example demonstrates how to build a pipeline from a mix of:\n",
+    "* lightweight components (functions defined here in python code and built into components)\n",
+    "* off-the-shelf reusable components (defined by someone else and accessed directly from github)\n",
+    "\n",
+    "In doing this, we build a **shareable** pipeline - one that you can share with others and they can rerun on a new problem without needing this notebook.\n",
+    "\n",
+    "In particular, we use off-the-shelf components to enable our pipeline to write data to minio without needing to know how the minio python package/CLI works.\n",
+    "\n",
+    "This example builds on concepts from a few others - see those notebooks for more detail: \n",
+    "* The problem solved here is from [Compute Pi](../mapreduce-pipeline/Compute-Pi.ipynb) \n",
+    "* We use lightweight components, which have some important [quirks](../kfp-basics/demo_kfp_lightweight_components.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from typing import NamedTuple\n",
+    "\n",
+    "import kfp\n",
+    "from kfp import dsl, compiler\n",
+    "from kfp.components import func_to_container_op\n",
+    "from kfp.components import load_component_from_file\n",
+    "\n",
+    "# TODO: Move utilities to a central repo\n",
+    "from utilities import get_minio_credentials"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Problem Description\n",
+    "\n",
+    "Our task is to compute an estimate of Pi by:\n",
+    "1. picking some random points\n",
+    "1. evaluating whether the points are inside a unit circle\n",
+    "1. aggregating (2) to estimate pi\n",
+    "\n",
+    "Our solution to this task here focuses on:\n",
+    "* making a fully reusable pipeline:\n",
+    "    * The pipeline should be sharable.  You should be able to share the pipeline by giving them the pipeline.yaml file **without** sharing this notebook\n",
+    "    * All user inputs are adjustable at runtime (no editing the YAML, changing hard-coded settings in the python code, etc.)\n",
+    "* persisting data in minio\n",
+    "* using existing, reusable components where possible\n",
+    "    * Ex: rather than teach our sample function to store results in minio, we use an existing component to store results\n",
+    "    * This helps improve testability and reduces work when building new pipelines"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Pipeline pseudocode"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To solve our problem, we need to: \n",
+    "* Generate N random seeds\n",
+    "    * For each random seed, do a sample step\n",
+    "    * For each sample step, store the result to a location in minio\n",
+    "* Collect all sample results\n",
+    "* Compute pi (by averaging the results)\n",
+    "* Save the final result to minio"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In pseudocode our pipeline looks like:"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "```python\n",
+    "def compute_pi(n_samples: int,\n",
+    "               output_location: str,\n",
+    "               minio_credentials, \n",
+    "              ):\n",
+    "    seeds = create_seeds(n_samples)\n",
+    "\n",
+    "    for seed in seeds:\n",
+    "        result = sample(seed)\n",
+    "        copy_to_minio(minio_credentials, result, output_location)\n",
+    "    \n",
+    "    all_sample_results = collect_all_results(minio_credentials,\n",
+    "                                             sample_output_location\n",
+    "                                            )\n",
+    "    \n",
+    "    final_result = average(all_sample_results)\n",
+    "    \n",
+    "    copy_to_minio(minio_credentials, final_result, output_location)\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "where we've pulled anything the user might want to set at runtime (the number of samples, the location in minio for results to be placed, and their minio credentials) out as pipeline arguments.\n",
+    "\n",
+    "Now lets fill in all the function calls with components"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Define Components for our specific Business Logic"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For any operation that is specific to our problem (for example, how we train a model, how we transform a data file, ...) we need a component that does our specific task.  These are defined below.\n",
+    "\n",
+    "**NOTE:** We define the component python code here, but you could pull these from .py files or elsewhere"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## create_seeds"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To create our random seeds, we define a component that takes n_samples list of n_samples seeds.  The seeds here are arbitrary (although we've defined them such that they will be unique and reproducible).\n",
+    "\n",
+    "While it might feel like we could simply do this in `compute_pi()`: \n",
+    "```\n",
+    "seeds = [i for i in range(n_samples)]\n",
+    "```\n",
+    "we cannot because n_samples is a pipeline runtime argument.  When we run this notebook to define the pipeline, n_samples is a **placeholder** rather than an actual integer.  Thus, the generation of samples must occur at pipeline runtime rather than in the pipeline definition itself.  "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def create_seeds_func(n_samples: int) -> list:\n",
+    "    \"\"\"\n",
+    "    Creates n_samples seeds and returns as a list\n",
+    "\n",
+    "    Note: When used as an operation in a KF pipeline, the list is serialized\n",
+    "    to a string.  Can deserialize with strip and split or json package\n",
+    "    This sort of comma separated list will work natively with KF Pipelines'\n",
+    "    parallel for (we can feed this directly into a parallel for loop and it\n",
+    "    breaks into elements for us)\n",
+    "\n",
+    "    \"\"\"\n",
+    "    constant = 10  # just so I know something is happening\n",
+    "    return [constant + i for i in range(n_samples)]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "By defining this function in python first, we can test it here to make sure it works as expected (rigorous testing omitted here, but recommended for your own tasks)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[10, 11, 12, 13, 14, 15, 16, 17, 18, 19]\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Very rigorous testing!\n",
+    "print(create_seeds_func(10))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "And we can then convert our tested function to a task constructor using `func_to_container_op`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Define the base image our code will run from.\n",
+    "# This is reused in a few components\n",
+    "base_image_python = \"python:3.7.6-buster\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "create_seeds_op = func_to_container_op(create_seeds_func,\n",
+    "                                       base_image=base_image_python,\n",
+    "                                       )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This task constructor `create_seeds_op` is what actually creates instances of these components in our pipeline.  "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## sample"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Similar to above, we a sample function and corresponding task constructor"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def sample_func(seed: int) -> NamedTuple('Outputs', [('x', float), ('y', float), ('result', int), ('seed', int)]):\n",
+    "    \"\"\"\n",
+    "    Define the \"sample\" pipeline operation\n",
+    "\n",
+    "    Args:\n",
+    "        seed (int): Integer seed used for random calculation\n",
+    "\n",
+    "    Returns:\n",
+    "        The result of this operation will be a named tuple with:\n",
+    "        {\n",
+    "             \"x\" : x-coordinate,\n",
+    "             \"y\" : y-coordinate,\n",
+    "             \"result\" : 4 if in unit-circle, 0 otherwise,\n",
+    "             \"seed\" : the input seed value,\n",
+    "        }\n",
+    "    \"\"\"\n",
+    "    from collections import namedtuple\n",
+    "    import random\n",
+    "    random.seed(seed)\n",
+    "\n",
+    "    print(\"Pick random point\")\n",
+    "    # x,y ~ Uniform([-1,1])\n",
+    "    x = random.random() * 2 - 1\n",
+    "    y = random.random() * 2 - 1\n",
+    "    print(f\"Sample selected: ({x}, {y})\")\n",
+    "\n",
+    "    if (x ** 2 + y ** 2) <= 1:\n",
+    "        print(f\"Random point is inside the unit circle\")\n",
+    "        result = 4\n",
+    "    else:\n",
+    "        print(f\"Random point is outside the unit circle\")\n",
+    "        result = 0\n",
+    "    # Return output in the same structure as defined in the NamedTuple type hint\n",
+    "    output_spec = namedtuple(\"output\", (\"x\", \"y\", \"result\", \"seed\"))\n",
+    "    output = output_spec(x, y, result, seed)\n",
+    "    return output"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# (insert your testing here)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sample_op = func_to_container_op(sample_func,\n",
+    "                                 base_image=base_image_python,\n",
+    "                                 )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## average"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def average_func(numbers) -> float:\n",
+    "    \"\"\"\n",
+    "    Computes the average value of a JSON list of numbers, returned as a float\n",
+    "    \"\"\"\n",
+    "    import json\n",
+    "    print(numbers)\n",
+    "    print(type(numbers))\n",
+    "    numbers = json.loads(numbers)\n",
+    "    return sum(numbers) / len(numbers)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# (and even more testing here!)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "average_op = func_to_container_op(average_func,\n",
+    "                                  base_image=base_image_python,\n",
+    "                                  )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Use Reusable Components for the rest"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For any generic operations in our pipeline, we can reuse components that were defined by others.  In particular, interactions with minio here are good candidates for generic, reusable components.  \n",
+    "\n",
+    "Reusable components can be loaded directly from compiled yaml files - we just have to point to them.  Think of them roughly as imported functions.  They can come from local text files, or be imported directly from github/internet.  \n",
+    "\n",
+    "These yaml files are approachable - open them up to see how they work!\n",
+    "\n",
+    "**TODO: Move reusables to github**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Component that takes a file and puts it into minio\n",
+    "copy_to_minio_op = load_component_from_file('./components/copy_to_minio.yaml')\n",
+    "\n",
+    "# Component that does an \"mc find\" operation, finding files in minio that \n",
+    "# match a pattern\n",
+    "mc_find_op = load_component_from_file('./components/minio_find.yaml')\n",
+    "\n",
+    "# Component that takes a list of files and concatenates their contents to a JSON\n",
+    "# list\n",
+    "mc_cat_files_to_json_op = load_component_from_file('./components/minio_cat_files_to_json.yaml')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Define and Compile Pipeline"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "With our component constructors defined, we build our full pipeline.  Remember that while we use a python function to define our pipeline here, anything that depends on a KFP-specific entity (an input argument, a component result, etc) is computed at runtime in kubernetes.  This means we can't do things like \n",
+    "```\n",
+    "for seed in seeds:\n",
+    "    sample_op = sample_op(seed)\n",
+    "```\n",
+    "because Python would try to interpret seeds, which is a *placeholder* object for a future value, as an iterable."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "@dsl.pipeline(\n",
+    "    name=\"Estimate Pi w/Minio\",\n",
+    "    description=\"Extension of the Map-Reduce example using dynamic number of samples and Minio for storage\"\n",
+    ")\n",
+    "def compute_pi(n_samples: int, output_location: str, minio_url,\n",
+    "               minio_access_key: str, minio_secret_key: str):\n",
+    "    seeds = create_seeds_op(n_samples)\n",
+    "\n",
+    "    # We add the KFP RUN_ID here in the output location so that we don't\n",
+    "    # accidentally overwrite another run.  There's lots of ways to manage\n",
+    "    # data, this is just one possibility.\n",
+    "    this_run_output_location = f\"{str(output_location).rstrip('/')}\" \\\n",
+    "                               f\"/{kfp.dsl.RUN_ID_PLACEHOLDER}\"\n",
+    "\n",
+    "    sample_output_location = f\"{this_run_output_location}/seeds\"\n",
+    "\n",
+    "    copy_ops = []\n",
+    "    with kfp.dsl.ParallelFor(seeds.output) as seed:\n",
+    "        sample_op_ = sample_op(seed)\n",
+    "\n",
+    "        # NOTE: A current limitation of the ParallelFor loop in KFP is that it\n",
+    "        # does not give us an easy way to collect the results afterwards.  To\n",
+    "        # get around this problem, we store results in a known place in minio\n",
+    "        # and later glob the result files back out\n",
+    "        #\n",
+    "        # Save the result from this sample to minio in\n",
+    "        # ./seeds/{seed}/result.out.  We save with {seed} in the filepath to\n",
+    "        # prevent different paths from otherwriting each other.  Note that\n",
+    "        # this relies on seed being unique\n",
+    "        #\n",
+    "        # TODO: Could we do an append-to-file-in-minio and concatenate them \n",
+    "        # on the fly? Would minio have issues with simultaneous writes?\n",
+    "        copy_sample = copy_to_minio_op(\n",
+    "            minio_url,\n",
+    "            minio_access_key,\n",
+    "            minio_secret_key,\n",
+    "            sample_op_.outputs['result'],\n",
+    "            f\"{sample_output_location}{seed}/result.out\",\n",
+    "        )\n",
+    "\n",
+    "        # Make a list of copy_ops so we can do result collection after they finish\n",
+    "        copy_ops.append(copy_sample)\n",
+    "\n",
+    "    # Collect all result.out files in the sample_output_location and concatenate\n",
+    "    # their contents as a json list\n",
+    "    search_pattern = r'/result.out'\n",
+    "    files_to_cat = mc_find_op(\n",
+    "        minio_url,\n",
+    "        minio_access_key,\n",
+    "        minio_secret_key,\n",
+    "        sample_output_location,\n",
+    "        search_pattern,\n",
+    "    )\n",
+    "\n",
+    "    # files_to_cat requires all sample_ops to be done before running (all\n",
+    "    # results must be generated first).  Enforce this by setting files_to_cat\n",
+    "    # to be .after() all copy_op tasks\n",
+    "    for op in copy_ops:\n",
+    "        files_to_cat.after(op)\n",
+    "\n",
+    "    all_samples = mc_cat_files_to_json_op(\n",
+    "        minio_url,\n",
+    "        minio_access_key,\n",
+    "        minio_secret_key,\n",
+    "        files_to_cat.output,\n",
+    "    )\n",
+    "\n",
+    "    final_result = average_op(all_samples.output)\n",
+    "\n",
+    "    copy_average = copy_to_minio_op(\n",
+    "        minio_url,\n",
+    "        minio_access_key,\n",
+    "        minio_secret_key,\n",
+    "        final_result.output,\n",
+    "        f\"{this_run_output_location}/result.out\",\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Compile our pipeline into a reusable YAML file"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exported pipeline definition to compute-pi-with-reusables.zip\n"
+     ]
+    }
+   ],
+   "source": [
+    "experiment_name = \"compute-pi-with-reusables\"\n",
+    "experiment_yaml_zip = experiment_name + '.zip'\n",
+    "compiler.Compiler().compile(\n",
+    "    compute_pi,\n",
+    "    experiment_yaml_zip\n",
+    ")\n",
+    "print(f\"Exported pipeline definition to {experiment_yaml_zip}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Run"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Use our above pipeline definition to do our task.  Note that anything below here can be done **without** the above code.  All we need is the yaml file from the last step.  We can even do this from the Kubeflow Pipelines UI or from a terminal."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## User settings\n",
+    "Update the next block to match your own setup.  bucket will be your namespace (likely your firstname-lastname), and output_location is where inside the bucket you want to put your results"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Python Minio SDK expects bucket and output_location to be separate\n",
+    "output_location = \"andrew-scribner/map-reduce-output\"\n",
+    "n_samples = 10\n",
+    "minio_tenant = \"minimal\"  # probably can leave this as is"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Trying to access minio credentials from:\n",
+      "/vault/secrets/minio-minimal-tenant1\n"
+     ]
+    }
+   ],
+   "source": [
+    "output_location = \"andrew-scribner/map-reduce-output\"\n",
+    "n_samples = 10\n",
+    "\n",
+    "# Get minio credentials using a helper\n",
+    "minio_settings = get_minio_credentials(minio_tenant, strip_http=False)\n",
+    "minio_url = minio_settings[\"url\"]\n",
+    "minio_access_key = minio_settings[\"access_key\"]\n",
+    "minio_secret_key = minio_settings[\"secret_key\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "Experiment link <a href=\"/pipeline/#/experiments/details/745736c2-db59-4b06-bbea-94d83d30d256\" target=\"_blank\" >here</a>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "Run link <a href=\"/pipeline/#/runs/details/97b03ec7-b390-4476-812e-ffb2676e59a0\" target=\"_blank\" >here</a>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "client = kfp.Client()\n",
+    "result = client.create_run_from_pipeline_func(\n",
+    "    compute_pi,\n",
+    "    arguments={\"n_samples\": n_samples,\n",
+    "               \"output_location\": output_location,\n",
+    "               \"minio_url\": minio_url,\n",
+    "               \"minio_access_key\": minio_access_key,\n",
+    "               \"minio_secret_key\": minio_secret_key,\n",
+    "               },\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "(Optional)\n",
+    "\n",
+    "Wait for the run to complete, then print that it is done"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "wait_result = result.wait_for_run_completion(timeout=300)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Run 97b03ec7-b390-4476-812e-ffb2676e59a0\n",
+      "\tstarted at \t2020-06-26 17:54:15+00:00\n",
+      "\tfinished at \t2020-06-26 17:58:40+00:00\n",
+      "\twith status Succeeded\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(f\"Run {wait_result.run.id}\\n\\tstarted at \\t{wait_result.run.created_at}\\n\\tfinished at \\t{wait_result.run.finished_at}\\n\\twith status {wait_result.run.status}\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/mapreduce-pipeline/components/copy_to_minio.yaml
+++ b/mapreduce-pipeline/components/copy_to_minio.yaml
@@ -1,0 +1,27 @@
+name: Upload to Minio
+inputs:
+- {name: Minio URL, type: URL, description: 'Minio instance URL, starting with http://'}
+- {name: Minio access key, type: String}
+- {name: Minio secret key, type: String}
+- {name: Local file, description: 'Data to upload to Minio'}
+- {name: Minio destination, type: String, description: 'Minio destination in format <bucket>/<location_in_bucket>.'}
+outputs: 
+- {name: Minio destination, type: String}
+implementation:
+  container:
+    image: minio/mc
+    command:
+    - sh
+    - -ex
+    - -c
+    - |
+        mkdir -p "$(dirname "$5")"
+        mc config host add my_minio $0 $1 $2
+        mc cp $3 my_minio/$4
+        echo "$4" > "$5"
+    - {inputValue: Minio URL}
+    - {inputValue: Minio access key}
+    - {inputValue: Minio secret key}
+    - {inputPath: Local file}
+    - {inputValue: Minio destination}
+    - {outputPath: Minio destination}

--- a/mapreduce-pipeline/components/minio_cat_files_to_json.yaml
+++ b/mapreduce-pipeline/components/minio_cat_files_to_json.yaml
@@ -1,0 +1,29 @@
+name: Concatenate Minio Files to Local File
+inputs:
+- {name: Minio URL, type: URL, description: 'Minio instance URL, starting with http://'}
+- {name: Minio access key, type: String}
+- {name: Minio secret key, type: String}
+- {name: Files, type: String, description: 'Space separated list of minio files to concatenate in format <bucket>/<location_in_bucket>'}
+outputs: 
+- {name: Concatenated File, type: String}
+implementation:
+    container:
+        image: minio/mc
+        command:
+        - sh
+        - -ex
+        - -c
+        - |
+            mkdir -p "$(dirname "$4")"
+            mc config host add my_minio $0 $1 $2
+            echo -n "[ " > $4
+            for f in $3;
+            do
+                (mc cat ${f}; printf ", ")
+            done | sed 's/, $//' >> $4
+            echo -n " ]" >> $4
+        - {inputValue: Minio URL}
+        - {inputValue: Minio access key}
+        - {inputValue: Minio secret key}
+        - {inputValue: Files}
+        - {outputPath: Concatenated File}

--- a/mapreduce-pipeline/components/minio_find.yaml
+++ b/mapreduce-pipeline/components/minio_find.yaml
@@ -1,0 +1,26 @@
+name: mc_find
+inputs:
+- {name: Minio URL, type: URL, description: 'Minio instance URL, starting with http://'}
+- {name: Minio access key, type: String}
+- {name: Minio secret key, type: String}
+- {name: Base Path, description: 'Path in minio to start search from'}
+- {name: Pattern, type: String, description: 'Regex pattern to search with'}
+outputs: 
+- {name: Files, type: String}
+implementation:
+  container:
+    image: minio/mc
+    command:
+    - sh
+    - -ex
+    - -c
+    - |
+        mkdir -p "$(dirname "$5")"
+        mc config host add my_minio $0 $1 $2
+        mc find my_minio/$3 --regex $4 > $5
+    - {inputValue: Minio URL}
+    - {inputValue: Minio access key}
+    - {inputValue: Minio secret key}
+    - {inputValue: Base Path}
+    - {inputValue: Pattern}
+    - {outputPath: Files}

--- a/mapreduce-pipeline/utilities.py
+++ b/mapreduce-pipeline/utilities.py
@@ -1,0 +1,132 @@
+import re
+
+
+def parse_env_var_def(s):
+    """
+    Parse a string defining a shell environment variable, returning name and value
+
+    Returns (varname, value) if matching pattern, else None
+    """
+    match = re.search(r"\s*(?<=export)\s+([^=]+)=(.*)", s)
+    if match:
+        lhs, rhs = match.groups()
+
+        # Remove whitespace and any quoted strings' quotes
+        lhs = lhs.strip().strip('\'').strip('"')
+        rhs = rhs.strip().strip('\'').strip('"')
+        # If both sides exist, return them
+        if lhs and rhs:
+            return lhs, rhs
+    return None
+
+def get_env_variables_from_file(filepath):
+    """
+    Returns a dictionary of the environment variables defined in a file
+    """
+    with open(filepath, 'r') as fin:
+        lines = fin.readlines()
+    lines = [parse_env_var_def(line) for line in lines]
+
+    # Return a dict of lhs:rhs, skipping any lines that are blank
+    return {line[0]: line[1] for line in lines if line}
+
+
+def get_minio_credentials(tenant, strip_http=True, verbose=True):
+    """
+    Retrieve minio credentials from the vault (available from notebook server)
+
+    Args:
+        strip_http (bool): If True, strips http:// from the start of the minio URL
+        tenant (str): Minio tenant name, such as "minimal" or "premium"
+        
+    Returns:
+        (dict): Dict with keys:
+            url
+            access_key
+            secret_key
+    """
+    vault = f"/vault/secrets/minio-{tenant}-tenant1"
+    if verbose:
+        print("Trying to access minio credentials from:")
+        print(vault)
+    d = get_env_variables_from_file(vault)
+
+    # Select only the keys that we want, also checking that they exist at all
+    key_map = {
+        "MINIO_URL": "url",
+        "MINIO_ACCESS_KEY": "access_key",
+        "MINIO_SECRET_KEY": "secret_key",
+    }
+    minio_credentials = {}
+    for k in key_map:
+        try:
+            minio_credentials[key_map[k]] = d[k]
+        except KeyError:
+            raise KeyError(f"Cannot find minio credential {k} in vault file")
+
+    if strip_http:
+        # Get rid of http:// in minio URL
+        minio_credentials["url"] = re.sub(r'^https?://',
+                                          "",
+                                          minio_credentials["url"],
+                                          )
+
+    return minio_credentials
+
+
+def create_bucket_if_missing(minio_obj, bucket):
+    if not minio_obj.bucket_exists(bucket):
+        minio_obj.make_bucket(bucket)
+        print(f"Created bucket {bucket}")
+
+
+def copy_to_minio(minio_url, bucket, access_key, secret_key, sourcefile,
+                  destination):
+    from minio import Minio
+
+    # Store results to minio
+    s3 = Minio(
+        minio_url,
+        access_key=access_key,
+        secret_key=secret_key,
+        secure=False,
+        region="us-west-1",
+    )
+
+    # Create bucket if needed
+    create_bucket_if_missing(s3, bucket)
+
+    # Put file into bucket
+    s3.fput_object(bucket, destination, sourcefile)
+
+    
+def minio_find_files_matching_pattern(minio_url, bucket, access_key, secret_key,
+                                      pattern, prefix='', recursive=True):
+    """
+    Returns all files in a minio location that match the given pattern
+
+    This function is glob-like in idea, but uses regex patterns instead
+    of glob patterns.
+    """
+    import re
+    from minio import Minio
+    pattern = re.compile(pattern)
+
+    s3 = Minio(
+        minio_url,
+        access_key=access_key,
+        secret_key=secret_key,
+        secure=False,
+        region="us-west-1",
+    )
+
+    # Get everything in bucket/prefix
+    objs = s3.list_objects(bucket, prefix=prefix, recursive=True)
+
+    # Discard directories
+    filepaths = [obj.object_name for obj in objs if not obj.is_dir]
+
+    # Select only those that fit the pattern
+    matching = [filepath for filepath in filepaths if pattern.match(filepath)]
+
+    return matching


### PR DESCRIPTION
Adds two variants on the map-reduce pipeline.  Both use lightweight components, support user-specified n_samples at runtime, and store data in minio.  One uses lightweight components written to interact with minio directly, the other uses reusable components from elsewhere.